### PR TITLE
Enable admin access from settings

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -16,6 +16,7 @@ import SelectTime from "./pages/SelectTime";
 import MyAppointments from "./pages/MyAppointments";
 import TreatmentHistory from "./pages/TreatmentHistory";
 import Settings from "./pages/Settings";
+import Admin from "./pages/Admin";
 
 import PrivateRoute from "./components/PrivateRoute";
 import PublicRoute from "./components/PublicRoute";
@@ -90,6 +91,14 @@ function App() {
             element={
               <PrivateRoute>
                 <Settings />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/admin"
+            element={
+              <PrivateRoute requireAdmin={true}>
+                <Admin />
               </PrivateRoute>
             }
           />

--- a/client/src/pages/Admin.jsx
+++ b/client/src/pages/Admin.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function Admin() {
+  return (
+    <div className="min-h-screen bg-[#ffedee] p-6">
+      <h1 className="text-2xl font-semibold text-[#000200] mb-4">Admin Page</h1>
+      <p className="text-[#000200]">Welcome, admin!</p>
+    </div>
+  );
+}

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -1,12 +1,11 @@
 import React, { useContext } from "react";
 import { useNavigate } from "react-router-dom";
+import { ChevronRight } from "lucide-react";
 import { AuthContext } from "../AuthContext";
 
 export default function Settings() {
   const { logout, user } = useContext(AuthContext);
   const navigate = useNavigate();
-
-  console.log(user);
 
 
   const handleLogout = () => {
@@ -17,6 +16,15 @@ export default function Settings() {
   return (
     <div className="min-h-screen bg-[#ffedee] p-6 flex flex-col">
       <h1 className="text-2xl font-semibold text-[#000200] mb-6">Settings</h1>
+
+      {user?.role === "admin" && (
+        <button
+          onClick={() => navigate("/admin")}
+          className="bg-white text-[#000200] text-xl py-4 px-4 rounded-xl shadow flex justify-between items-center mb-4"
+        >
+          Admin Panel <ChevronRight className="text-[#e79992]" />
+        </button>
+      )}
 
       <button
         onClick={handleLogout}


### PR DESCRIPTION
## Summary
- add an Admin page
- show `Admin Panel` button in Settings for admins
- secure the `/admin` route with `PrivateRoute`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ead0bfbec832b860825b355a1af4a